### PR TITLE
Add `https://` to `opendata.scot` URLs.

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,15 +9,15 @@ Looking to learn more about what repositories we have? Check out the information
 ### [the_od_bods](https://github.com/OpenDataScotland/the_od_bods)
 The original repository that was set up off the back of this project starting at [Code The City 23](https://codethecity.org/2021/06/13/3689/) where we collated open datasets across local authorities in Scotland.
 
-We now use this as our main repository for tracking project process, wiki documentation and scripting toolsets we use to scrape data for our website, [opendata.scot](opendata.scot)
+We now use this as our main repository for tracking project process, wiki documentation and scripting toolsets we use to scrape data for our website, [opendata.scot](https://opendata.scot)
 
 ### [jkan](https://github.com/OpenDataScotland/jkan)
 
-A lightweight, backend-free open data portal, powered by Jekyll and originally created by [timwis](https://github.com/timwis)). This repository holds the source code we use to generate the static site pages for [opendata.scot](opendata.scot).
+A lightweight, backend-free open data portal, powered by Jekyll and originally created by [timwis](https://github.com/timwis)). This repository holds the source code we use to generate the static site pages for [opendata.scot](https://opendata.scot).
 
 ### [opendata.scot_pipeline](https://github.com/OpenDataScotland/opendata.scot_pipeline)
 
-Created at [Code The City 26](https://codethecity.org/what-we-do/hack-weekends/ctc26/) as part of our milestone to automate our dataset gathering process. This repository holds the GitHub Actions workflow for automatically running our data scraping scripts on a regular basis to update the datasets shown on [opendata.scot/datasets](opendata.scot)
+Created at [Code The City 26](https://codethecity.org/what-we-do/hack-weekends/ctc26/) as part of our milestone to automate our dataset gathering process. This repository holds the GitHub Actions workflow for automatically running our data scraping scripts on a regular basis to update the datasets shown on [opendata.scot/datasets](https://opendata.scot/datasets)
 
 ### [opendata.scot_analytics](https://github.com/OpenDataScotland/opendata.scot_analytics)
 


### PR DESCRIPTION
`opendata.scot` is not autodetected as a URL in the profile page on https://github.com/OpenDataScotland. Instead it's handled as a relative link to a file called `opendata.scot` which obviously doesn't exist.